### PR TITLE
DOCS-1137: Adding support disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 The OneLogin NAPPS Toolkits provide SDKs and demo projects that will help you integrate OneLogin's NAPPS into your native application. We provide toolkits for iOS, Android, and PhoneGap.
 
 **Note:** The PhoneGap demo projects can be used with the Test Token Agents for the Android and iOS platforms.
+
+## Support
+
+OneLogin by One Identity open source projects are supported through [OneLogin GitHub issues](https://github.com/onelogin/napps/issues). This includes all scripts, plugins, SDKs, modules, code snippets or other solutions. For assistance with any OneLogin by One Identity GitHub project, please raise a new Issue on the [OneLogin GitHub issues](https://github.com/onelogin/napps/issues) page. Requests for assistance made through official One Identity Support will be referred back to GitHub where those requests can benefit all users.


### PR DESCRIPTION
This pull request includes an update to the README.md file to provide information on how to get support for OneLogin open source projects.

Documentation update:

README.md: Added a new "Support" section that directs users to the OneLogin GitHub issues page for assistance with scripts, plugins, SDKs, modules, code snippets, or other solutions.